### PR TITLE
Set up Cursor Cloud dev environment for LLVM/Clang

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is the **LLVM monorepo** (a personal fork of `llvm/llvm-project`,
+including `libsycl`). It is a large C++/CMake codebase; the "application" is the
+LLVM/Clang compiler toolchain (`clang`, `lld`, `llc`, `opt`, `llvm-mc`, ...).
+
+### Toolchain already present (installed during environment setup)
+- `clang-18` / `clang++-18`, `g++`/GCC 13, `cmake` 3.28, `python3` 3.12.
+- `ninja`, `ccache`, `lld` (installed via apt during setup).
+
+### Non-obvious gotcha: which GCC clang uses for libstdc++
+The VM has GCC 13 **and** GCC 14, but only GCC 13 ships the `libstdc++` dev files
+(`libstdc++.so` + C++ headers). `clang` picks the newest GCC (14) by default and
+then fails to find `libstdc++` when compiling/linking **C++** code
+(`cannot find -lstdc++` or `'iostream' file not found`). `libstdc++-14-dev` cannot
+be installed here because the Ubuntu package pool returns 503 on this network.
+
+Workaround — point clang at GCC 13 for C++:
+```
+--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13
+```
+This applies to **both** the system `clang-18` and the freshly built `clang` when
+compiling C++ (add `-Wno-gcc-install-dir-libstdcxx` to silence the advisory
+warning). Plain C programs are unaffected.
+
+### Configuring the build (reference)
+Build out-of-tree from the `llvm/` subdirectory into `/workspace/build`
+(`/build*` is gitignored). The configuration used for the dev build:
+```
+cmake -S llvm -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_ENABLE_PROJECTS="clang;lld" \
+  -DLLVM_TARGETS_TO_BUILD=X86 \
+  -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+  -DCMAKE_C_FLAGS="--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13" \
+  -DCMAKE_CXX_FLAGS="--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13" \
+  -DLLVM_ENABLE_LLD=ON \
+  -DLLVM_CCACHE_BUILD=ON \
+  -DLLVM_APPEND_VC_REV=OFF
+```
+Two flags matter in this environment:
+- `LLVM_APPEND_VC_REV=OFF`: the cloud clone URL embeds an access token, so
+  `VCSRevision.h` generation otherwise aborts ("git remote URL has an embedded
+  password"). Turning it off avoids the failure.
+- Do **not** enable `LLVM_OPTIMIZED_TABLEGEN`: it spawns a `NATIVE/` sub-build
+  that re-runs CMake **without** the `--gcc-install-dir` flags and fails on
+  `-lstdc++`.
+
+### Build / run / test
+- Build (use ninja, no `-j`; it auto-detects cores; ccache warms rebuilds):
+  `ninja -C build clang lld llc opt llvm-mc`
+- Run the compiler, e.g.: `build/bin/clang <src.c>` (for C++ add the
+  `--gcc-install-dir=...13` flag above).
+- Tests use LLVM `lit`. Prefer the generated `check-*` ninja targets, which
+  auto-build the tool dependencies (running `build/bin/llvm-lit` directly fails
+  until tools like `llvm-config`, `FileCheck`, `verify-uselistorder`, etc. are
+  built). Example targeted suite: `ninja -C build check-llvm-mc-x86`.
+  The full suite is `ninja -C build check-llvm` (very large).
+- Lint/format: LLVM uses `clang-format` (`.clang-format`) and `.clang-tidy`;
+  format only your diff, e.g. `git clang-format` / `clang-format -i <files>`.
+
+### Network note
+apt access to `archive.ubuntu.com` / `security.ubuntu.com` is intermittent
+(frequent 503s from the egress proxy). Avoid depending on new apt installs at
+runtime; the build tools above are already installed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this LLVM monorepo in Cursor Cloud. No source code was modified; the only tracked change is a new `AGENTS.md` capturing durable, non-obvious setup knowledge for future cloud agents.

## What was done
- Installed build tooling: `ninja`, `ccache`, `lld` (`clang-18`/`g++`/`cmake`/`python3` were already present).
- Configured a dev build (`Release` + assertions, `clang;lld`, `X86` target) from `llvm/` into `/workspace/build` using `clang-18` + `lld` + `ccache`.
- Built `clang`, `lld`, `llc`, `opt`, `llvm-mc` (clang `23.0.0git`).
- Verified the toolchain end-to-end (hello-world + full IR pipeline) and ran a lit suite.

## Key environment gotcha (documented in AGENTS.md)
The VM has GCC 13 (with `libstdc++` dev files) and GCC 14 (runtime only). Clang defaults to GCC 14 and fails on C++ (`cannot find -lstdc++`). `libstdc++-14-dev` is not installable (Ubuntu pool returns 503 here), so C++ compilation must pass `--gcc-install-dir=/usr/lib/gcc/x86_64-linux-gnu/13`. Also `LLVM_APPEND_VC_REV=OFF` is required (clone URL embeds a token), and `LLVM_OPTIMIZED_TABLEGEN` must stay off (its NATIVE sub-build ignores the gcc flags).

## Verification
- C: `clang hello.c` → runs.
- C++: `clang++ --gcc-install-dir=.../13 hello.cpp` → runs.
- Pipeline: `clang -emit-llvm` → `opt -O2` → `llc -mcpu=native`.
- Tests: `ninja -C build check-llvm-mc-x86` → **621/621 passed (100%)**.

Note: `AGENTS.md` is normally gitignored in this repo; it was force-added so these instructions persist for future agents.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-644d87dd-285f-419b-9d0e-094fe60dc648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-644d87dd-285f-419b-9d0e-094fe60dc648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

